### PR TITLE
Supersonic flutter

### DIFF
--- a/examples/plot_fin_flutter.py
+++ b/examples/plot_fin_flutter.py
@@ -12,7 +12,7 @@ matplotlib.use('PDF')
 
 import numpy as np
 from matplotlib import pyplot as plt
-from firefish.finflutter import model_atmosphere, flutter_velocity
+from firefish.finflutter import model_atmosphere, flutter_velocity_transonic, flutter_velocity_supersonic
 
 def main(output='flutter-velocity-example.pdf'):
     """
@@ -24,11 +24,13 @@ def main(output='flutter-velocity-example.pdf'):
 
     """
     zs = np.linspace(0, 50000, 200)
-    ps, _, ss = model_atmosphere(zs)
-    vs = flutter_velocity(ps, ss, 20, 10, 10, 0.2)
+    ps, ts, ss = model_atmosphere(zs)
+    rhos = ps / (0.2869 * (ts + 273.1))
+    vs_t = flutter_velocity_transonic(ps, ss, 20, 10, 10, 0.2)
+    vs_s = flutter_velocity_supersonic(rhos, 380, 104, 1, 0.3, 0.0313, 0.0855, 3)
 
     plt.figure()
-    plt.plot(zs * 1e-3, vs)
+    plt.plot(zs * 1e-3, vs_t)
     plt.title('Flutter velocity vs altitude')
     plt.xlabel('Altitude [km]')
     plt.ylabel('Flutter velocity [m/s]')

--- a/examples/plot_fin_flutter.py
+++ b/examples/plot_fin_flutter.py
@@ -23,7 +23,7 @@ def main(output='flutter-velocity-example.pdf'):
     >>> assert fobj.getvalue()[:4] == b'%PDF'
 
     """
-    zs = np.linspace(0, 50000, 200)
+    zs = np.linspace(0, 20000, 200)
     ps, ts, ss = model_atmosphere(zs)
     rhos = (ps/1000) / (0.2869 * (ts + 273.1))
     vs_t = flutter_velocity_transonic(ps, ss, 20, 10, 10, 0.2)

--- a/examples/plot_fin_flutter.py
+++ b/examples/plot_fin_flutter.py
@@ -25,15 +25,17 @@ def main(output='flutter-velocity-example.pdf'):
     """
     zs = np.linspace(0, 50000, 200)
     ps, ts, ss = model_atmosphere(zs)
-    rhos = ps / (0.2869 * (ts + 273.1))
+    rhos = (ps/1000) / (0.2869 * (ts + 273.1))
     vs_t = flutter_velocity_transonic(ps, ss, 20, 10, 10, 0.2)
     vs_s = flutter_velocity_supersonic(rhos, 380, 104, 1, 0.3, 0.0313, 0.0855, 3)
 
     plt.figure()
-    plt.plot(zs * 1e-3, vs_t)
+    plt.plot(zs * 1e-3, vs_t, 'r', label="transonic flutter velocity")
+    plt.plot(zs*1e-3, vs_s, 'g', label="supersonic flutter velocity, Mach 3")
     plt.title('Flutter velocity vs altitude')
     plt.xlabel('Altitude [km]')
     plt.ylabel('Flutter velocity [m/s]')
+    plt.legend()
     plt.savefig(output, format='PDF')
 
 if __name__ == '__main__':

--- a/firefish/finflutter.py
+++ b/firefish/finflutter.py
@@ -5,7 +5,7 @@ The transonic flutter velocity code comes from "Peak of flight" newsletter
 issue 291, which is itself a modified version of the equation in
 NACA paper 4197.
 
-The supersonic flutter criterion is from a thesis by J. Simmons at the 
+The supersonic flutter criterion is from a thesis by J. Simmons at the
 Air Force Institute of Technology, Ohio. (AFIT/GSS/ENY/09-J02), the torsional and
 bending frequencies have to be calculated for different geometries using
 finite element analysis in Solidworks.
@@ -22,9 +22,8 @@ function of altitude. These can then be plotted. For example:
 
     zs = np.linspace(0, 50000, 200)
     ps, _, ss = finflutter.model_atmosphere(zs)
-    vs = finflutter.flutter_velocity(
-        ps, ss, root_chord=20, tip_chord=10, semi_span=10, thickness=0.2
-    )
+    vs = finflutter.flutter_velocity_transonic(ps, ss, root_chord=20, +
+        tip_chord=10, semi_span=10, thickness=0.2)
 
     plt.plot(zs * 1e-3, vs)
     plt.grid()
@@ -95,7 +94,7 @@ def flutter_velocity_transonic(pressures, speeds_of_sound,
                      root_chord, tip_chord, semi_span, thickness,
                      shear_modulus=2.62e9):
     """Calculate transonic flutter velocities for a given fin design.
-    The equation is valid if the rocket is travelling at < M2.5 at the 
+    The equation is valid if the rocket is travelling at < M2.5 at the
     given altitude.
 
     Fin dimensions are given via the root_chord, tip_chord, semi_span and
@@ -107,7 +106,7 @@ def flutter_velocity_transonic(pressures, speeds_of_sound,
     >>> import numpy as np
     >>> zs = np.linspace(0, 30000, 100)
     >>> ps, _, ss = model_atmosphere(zs)
-    >>> vels = flutter_velocity(ps, ss, 20, 10, 10, 0.2)
+    >>> vels = flutter_velocity_transonic(ps, ss, 20, 10, 10, 0.2)
     >>> assert vels.shape == ps.shape
 
     Args:
@@ -138,29 +137,29 @@ def flutter_velocity_transonic(pressures, speeds_of_sound,
 
     return Vf
 
-def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_frequency, 
+def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_frequency,
                     mass, semi_span, radius_of_gyration, distance_to_COG, Mach_number):
-    
-    """
-    Calculate transonic flutter velocities for a given fin design.
+
+    """Calculate transonic flutter velocities for a given fin design.
     The equation is valid for freestream flow in the supersonic regime
     (>~M2.5)
 
-    Fin analysis have to be done for Solidworks in order to find the 
-    frequencies for bending and torsional modes, as well as the radius_of_gyration 
+    Fin analysis have to be done for Solidworks in order to find the
+    frequencies for bending and torsional modes, as well as the radius_of_gyration
     and distance_to_COG. Torsional and bending frequency are in rad/s, the semi-span
     will be given in metres.
 
     >>> import numpy as np
     >>> zs = np.linspace(0, 30000, 100)
-    >>> rhos = model_atmosphere(zs)
-    >>> vels = flutter_velocity(rhos, 380, 104, 1, 0.1, 0.2, 0.1, 3)
+   > >> ps, ts, ss = model_atmosphere(zs)
+    >>> rhos = (ps/1000) / (0.2869 * (ts + 273.1))
+    >>> vels = flutter_velocity_supersonic(rhos, 380, 104, 1, 0.1, 0.2, 0.1, 3)
     >>> assert vels.shape == ps.shape
 
     Args:
         semi_span: fin semi-span (m)
         air_densities: 1-d array of air density in kg/m^3  (np.array)
-        torsional frequency: uncoupled torsional frequency (rad/s) 
+        torsional frequency: uncoupled torsional frequency (rad/s)
         bending_frequency: uncoupled bending frequency of the fin (rad/s)
         mass: mass of fin (kg)
         Mach_number: mach number of rocket
@@ -174,7 +173,7 @@ def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_freq
     Vf = np.zeros_like(air_densities)
     air_densities = np.atleast_1d(air_densities).astype(np.float)
     #mass ratio
-    mr = mass / (air_densities * semi_span**2) 
+    mr = mass / (air_densities * semi_span**2)
     A = (mr * radius_of_gyration**2 * np.sqrt(Mach_number**2 - 1)) / (distance_to_COG * semi_span)
     #frequency ratio squared
     fr2 = (bending_frequency / torsional_frequency)**2

--- a/firefish/finflutter.py
+++ b/firefish/finflutter.py
@@ -91,8 +91,8 @@ def model_atmosphere(altitudes):
 
 
 def flutter_velocity_transonic(pressures, speeds_of_sound,
-                              root_chord, tip_chord, semi_span, thickness,
-                              shear_modulus=2.62e9):
+                               root_chord, tip_chord, semi_span, thickness,
+                               shear_modulus=2.62e9):
     """Calculate transonic flutter velocities for a given fin design.
     The equation is valid if the rocket is travelling at < M2.5 at the
     given altitude.
@@ -146,8 +146,8 @@ def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_freq
 
     Fin analysis have to be done for Solidworks in order to find the
     frequencies for bending and torsional modes, as well as the radius_of_gyration
-    and distance_to_COG. Torsional and bending frequency are in rad/s, the semi-span
-    will be given in metres.
+    and distance_to_COG. Torsional and bending frequency are in rad/s, the semi-span,
+    radius of gyration, and distance to COG will be given in metres.
 
     >>> import numpy as np
     >>> zs = np.linspace(0, 30000, 100)
@@ -178,7 +178,7 @@ def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_freq
     #frequency ratio squared
     fr2 = (bending_frequency / torsional_frequency)**2
     B = (1-fr2)**2 + 4*(distance_to_COG/radius_of_gyration)**2 * fr2
-    C = 2*(1+fr2**2)
+    C = 2*(1+fr2)
     Vf = semi_span * torsional_frequency * np.sqrt(A*B/C)
 
     return Vf

--- a/firefish/finflutter.py
+++ b/firefish/finflutter.py
@@ -171,10 +171,10 @@ def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_freq
     Returns:
         A 1-d array containing corresponding flutter velocities in m/s.
     """
-
+    Vf = np.zeros_like(air_densities)
     air_densities = np.atleast_1d(air_densities).astype(np.float)
     #mass ratio
-    mr = mass / semi_span 
+    mr = mass / (air_densities * semi_span**2) 
     A = (mr * radius_of_gyration**2 * np.sqrt(Mach_number**2 - 1)) / (distance_to_COG * semi_span)
     #frequency ratio squared
     fr2 = (bending_frequency / torsional_frequency)**2

--- a/firefish/finflutter.py
+++ b/firefish/finflutter.py
@@ -91,8 +91,8 @@ def model_atmosphere(altitudes):
 
 
 def flutter_velocity_transonic(pressures, speeds_of_sound,
-                     root_chord, tip_chord, semi_span, thickness,
-                     shear_modulus=2.62e9):
+                              root_chord, tip_chord, semi_span, thickness,
+                              shear_modulus=2.62e9):
     """Calculate transonic flutter velocities for a given fin design.
     The equation is valid if the rocket is travelling at < M2.5 at the
     given altitude.
@@ -138,7 +138,7 @@ def flutter_velocity_transonic(pressures, speeds_of_sound,
     return Vf
 
 def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_frequency,
-                    mass, semi_span, radius_of_gyration, distance_to_COG, Mach_number):
+                                mass, semi_span, radius_of_gyration, distance_to_COG, Mach_number):
 
     """Calculate transonic flutter velocities for a given fin design.
     The equation is valid for freestream flow in the supersonic regime
@@ -151,7 +151,7 @@ def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_freq
 
     >>> import numpy as np
     >>> zs = np.linspace(0, 30000, 100)
-   > >> ps, ts, ss = model_atmosphere(zs)
+    >>> ps, ts, ss = model_atmosphere(zs)
     >>> rhos = (ps/1000) / (0.2869 * (ts + 273.1))
     >>> vels = flutter_velocity_supersonic(rhos, 380, 104, 1, 0.1, 0.2, 0.1, 3)
     >>> assert vels.shape == ps.shape

--- a/firefish/finflutter.py
+++ b/firefish/finflutter.py
@@ -45,7 +45,7 @@ def model_atmosphere(altitudes):
         altitudes (np.array): 1-d array of geopotential altitudes in metres
 
     Returns:
-        A giving corresponding 1-d arrays of estimated pressure,
+        A triple giving corresponding 1-d arrays of estimated pressure,
         temperature and speed of sound. Units are Pascals, Celsius and m/s
         respectively.
 

--- a/firefish/finflutter.py
+++ b/firefish/finflutter.py
@@ -154,7 +154,7 @@ def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_freq
     >>> import numpy as np
     >>> zs = np.linspace(0, 30000, 100)
     >>> rhos = model_atmosphere(zs)
-    >>> vels = flutter_velocity(rhos, 380, 40, 1, 0.1, 0.2, 0.1, 3)
+    >>> vels = flutter_velocity(rhos, 380, 104, 1, 0.1, 0.2, 0.1, 3)
     >>> assert vels.shape == ps.shape
 
     Args:
@@ -178,8 +178,8 @@ def flutter_velocity_supersonic(air_densities, torsional_frequency, bending_freq
     A = (mr * radius_of_gyration**2 * np.sqrt(Mach_number**2 - 1)) / (distance_to_COG * semi_span)
     #frequency ratio squared
     fr2 = (bending_frequency / torsional_frequency)**2
-    B = (1-fr2)**2 + 4(distance_to_COG/radius_of_gyration)**2 * fr2
+    B = (1-fr2)**2 + 4*(distance_to_COG/radius_of_gyration)**2 * fr2
     C = 2*(1+fr2**2)
-    Vf = semi_span * torsional_frequency * sqrt(A*B/C)
+    Vf = semi_span * torsional_frequency * np.sqrt(A*B/C)
 
     return Vf


### PR DESCRIPTION
New function which calculates flutter at supersonic velocities (> Mach 2.5) based on the paper "Aero-elastic optimization of sounding rocket fins" by J Simmons (search AFIT/GSS/ENY/09-J02). The function is just a simple calculator which requires fin parameters: torsional and bending frequencies, distance to CoG from axis of rotation, radius of gyration (sqrt(moment of inertia/mass)), which at present will have to be derived from SolidWorks.

For some generic estimates for these values, it seems supersonic flutter occurs at velocities at ~50m/s less than for transonic flutter, and so poses more of a constraint.

PR also includes references to documentation for transonic and supersonic flutter calculations